### PR TITLE
Remove `token` field and add `query_name` field

### DIFF
--- a/config/logstash.config
+++ b/config/logstash.config
@@ -35,6 +35,24 @@ filter {
       role => "role"
     }
   }
+
+  mutate {
+    remove_field => [
+      "token"
+    ]
+  }
+
+  # Extract the query name and assign it to a new field 'query_name'
+  #
+  # Example log:
+  #
+  #       { "query": "query ActivitiesData($protocolWeekId: Int! ... }
+  #
+  grok {
+    match => {
+      "query" => "query %{WORD:query_name}\("
+    }
+  }
 }
 
 output {

--- a/config/logstash.config
+++ b/config/logstash.config
@@ -27,12 +27,14 @@ filter {
     ]
   }
 
-  jwt_decode {
-    key => "${SECRET_KEY_BASE}"
-    match => "token"
-    extract_fields => {
-      user_id => "user_id"
-      role => "role"
+  if [token] {
+    jwt_decode {
+      key => "${SECRET_KEY_BASE}"
+      match => "token"
+      extract_fields => {
+        user_id => "user_id"
+        role => "role"
+      }
     }
   }
 


### PR DESCRIPTION
* Removes JWT token from logs after it's been decoded
* Extracts the GQL query name and assigns it to the log event as `query_name`