### PR TITLE
Tuning capabilities & `query_name` fix

### DIFF
--- a/config/logstash.config
+++ b/config/logstash.config
@@ -50,9 +50,11 @@ filter {
   #
   #       { "query": "query ActivitiesData($protocolWeekId: Int! ... }
   #
-  grok {
-    match => {
-      "query" => "query %{WORD:query_name}\("
+  if [query] {
+    grok {
+      match => {
+        "query" => "query %{WORD:query_name}\("
+      }
     }
   }
 }
@@ -60,11 +62,11 @@ filter {
 output {
   elasticsearch {
     hosts => "${ELASTICSEARCH_URL}"
-    timeout => 1
-    sniffing => false
     pool_max => 1
-    template_name => "ja-logstash"
+    sniffing => false
     template => "/usr/share/logstash/index_template/ja_index_template.json"
+    template_name => "ja-logstash"
     template_overwrite => "true"
+    validate_after_inactivity: 200
   }
 }

--- a/config/logstash.config
+++ b/config/logstash.config
@@ -53,7 +53,7 @@ filter {
   if [query] {
     grok {
       match => {
-        "query" => "query %{WORD:query_name}\("
+        "query" => "query %{WORD:query_name}"
       }
     }
   }
@@ -67,6 +67,6 @@ output {
     template => "/usr/share/logstash/index_template/ja_index_template.json"
     template_name => "ja-logstash"
     template_overwrite => "true"
-    validate_after_inactivity: 200
+    validate_after_inactivity => 200
   }
 }

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -7,4 +7,4 @@ pipeline:
     # The maximum number of events an individual worker thread
     # will collect from inputs before attempting to execute
     # its filters and outputs.
-    size: ${BATCH_SIZE:10}
+    size: ${BATCH_SIZE:50}

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -2,11 +2,9 @@ http.host: "0.0.0.0"
 path.config: /usr/share/logstash/pipeline
 
 pipeline:
+  workers: ${NUM_WORKERS:1}
   batch:
     # The maximum number of events an individual worker thread
     # will collect from inputs before attempting to execute
     # its filters and outputs.
-    size: 10
-
-xpack.monitoring.enabled: false
-xpack.monitoring.elasticsearch.url: $ELASTICSEARCH_URL
+    size: ${BATCH_SIZE:10}


### PR DESCRIPTION
* Adds tuning capabilities via `NUM_WORKERS` and `BATCH_SIZE`
* Fixes `query_name` would only capture parameterized query names. It'll now capture non-parameterized queries.
* Fixes frequent "connection lost to ES"